### PR TITLE
The attribute name also responds to translation_metadata

### DIFF
--- a/lib/unival/utils.rb
+++ b/lib/unival/utils.rb
@@ -3,7 +3,7 @@ module Unival::Utils
     if v.is_a?(Array)
       v.map{|e| deep_translation_replace(e) }
     elsif v.is_a?(Hash)
-      v.each_with_object({}){|(k, v), o| o[deep_translation_replace(k)] = deep_translation_replace(v) }
+      v.each_with_object({}){|(k, v), o| o[k] = deep_translation_replace(v) }
     else
       if v.respond_to?(:translation_metadata)
         v.translation_metadata.fetch(:key)


### PR DESCRIPTION
If you actually call translation_metadata on the attribute name it will raise an error.
So removed the recursive call on the attribute name as that is not needed.